### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/LucasLagrimante/lagri-brawl/security/code-scanning/1](https://github.com/LucasLagrimante/lagri-brawl/security/code-scanning/1)

To fix the issue, add a `permissions` block with the minimum required privileges. Since the workflow (specifically, the `peaceiris/actions-gh-pages` action) needs to push to the `gh-pages` branch, it needs `contents: write` at a minimum. To follow the principle of least privilege, add a `permissions` key to the job (or at the root), and set `contents: write`. This will invoke the workflow with a GITHUB_TOKEN that only has write permission for repository content, not for issues, pull requests, or other secure areas. The best single change is to add the permissions block just above `runs-on` within the `build` job (**lines 10-11**), so it only applies to this job.

**Summary of what to change:**  
- Insert `permissions:` and `contents: write` at line 10, right before `runs-on: ubuntu-latest`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
